### PR TITLE
actions: Add skip job

### DIFF
--- a/.github/workflows/main-skip.yml
+++ b/.github/workflows/main-skip.yml
@@ -1,0 +1,30 @@
+name: robotframework-tests
+
+on:
+  push:
+    branches: [ main ]
+  paths-ignore:
+    - 'protos/**'
+    - 'tests/robot/**'
+    - '.github/workflows/main.yml'
+  pull_request:
+    branches: [ main ]
+  paths-ignore:
+    - 'protos/**'
+    - 'tests/robot/**'
+    - '.github/workflows/main.yml'
+
+concurrency:
+  # if workflow for PR or push is already running stop it, and start new one
+  group: poc-security-skip-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: tests/robot
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No security POC test run required"'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,19 @@
 name: robotframework-tests
 
 on:
+  workflow_dispatch:
   push:
-    branches: '**'
+    branches: [ main ]
+    paths:
+      - 'protos/**'
+      - 'tests/robot/**'
+      - '.github/workflows/main.yml'
   pull_request:
     branches: [ main ]
-  workflow_dispatch:
+    paths:
+      - 'protos/**'
+      - 'tests/robot/**'
+      - '.github/workflows/main.yml'
 
 defaults:
   run:


### PR DESCRIPTION
Add a skip job so we only run the robot tests when either the protobuf files change, or the robot tests themselves change.

Signed-off-by: Kyle Mestery <mestery@mestery.com>