### PR TITLE
renovate: Skip invalid Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,6 @@
   "extends": [
     "config:base"
   ],
+  "ignorePaths": ["openoffload/cpp/framework/Dockerfile/"],
   "includeForks": true
 }


### PR DESCRIPTION
This [1] Dockerfile references this [2] Dockerfile. However, nothing is building and pushing [2] yet. For now, lets disable renovate from trying to make sense of [1] until we get building and publishing working on this repository. This will let renovate do it's thing on the rest of the repository.

[1] https://github.com/opiproject/sessionOffload/blob/main/openoffload/cpp/framework/Dockerfile [2] https://github.com/opiproject/sessionOffload/blob/main/openoffload/cpp/framework/build/Dockerfile

Signed-off-by: Kyle Mestery <mestery@mestery.com>