### PR TITLE
framework: Update build

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: hadolint/hadolint-action@v2.1.0
         with:
           recursive: true
-          ignore: DL3041,DL3008,DL3033
+          ignore: DL3041,DL3008,DL3033,DL3002
           dockerfile: ${{ matrix.dockerfile }}
 
   shellcheck:

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ openoffload/cpp/tests/openoffload.grpc.pb.h
 openoffload/cpp/tests/openoffload.pb.cc
 openoffload/cpp/tests/openoffload.pb.h
 openoffload/cpp/framework/doc/html/**
+openoffload/cpp/framework/openoffload.proto
 openoffload/golang
 openoffload/python
 **/.DS_Store

--- a/openoffload/cpp/README.md
+++ b/openoffload/cpp/README.md
@@ -30,20 +30,23 @@ yum group install "Development Tools"
 ```
 
 ```bash
-wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.sh
+wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.23.4/cmake-3.23.4-Linux-x86_64.sh
 sh cmake-linux.sh -- --skip-license --prefix=$GRPC_INSTALL
 rm cmake-linux.sh
 export PATH=$GRPC_INSTALL/bin:$PATH
 ```
 
 ```bash
-git clone --recurse-submodules -b v1.30.0 https://github.com/grpc/grpc
+git clone --recurse-submodules -b v1.49.1 https://github.com/grpc/grpc
 cd grpc
 mkdir -p cmake/build
 pushd cmake/build
 cmake -DgRPC_INSTALL=ON \
       -DgRPC_BUILD_TESTS=OFF \
       -DCMAKE_INSTALL_PREFIX=$GRPC_INSTALL \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+      -DCMAKE_CXX_STANDARD=17 \
+      -DABSL_PROPAGATE_CXX_STD=TRUE \
       ../..
 make -j 4
 make install

--- a/openoffload/cpp/framework/Dockerfile
+++ b/openoffload/cpp/framework/Dockerfile
@@ -14,10 +14,9 @@ COPY Makefile /home/grpc/local/tests/Makefile
 
 RUN mkdir -p /home/protos
 
-COPY openoffload.proto /home/protos/
+COPY openoffload.proto /home/grpc/local/tests
 
-RUN ls ../../../sessionoffload/v2 && \
-    bash -c "mkdir -p {bin,obj,log}" && \
+RUN bash -c "mkdir -p {bin,obj,log}" && \
     make clean && \
     make HOME=/home/grpc all
 

--- a/openoffload/cpp/framework/Makefile
+++ b/openoffload/cpp/framework/Makefile
@@ -26,7 +26,7 @@ VERSION=1.0
 SERVER_LIB := libopof_server.so
 CLIENT_LIB := libopof_client.so
 #
-ROOT_DIR ?= $(HOME)/.local
+ROOT_DIR ?= $(HOME)
 MOUNT_PATH := ../../../
 #
 # CPP gRPC Definitions
@@ -77,77 +77,77 @@ CC := gcc -g
 CPP := g++ -g
 
 #CFLAGS := -c -O2 -I include -I /usr/local/include -I $(ROOT_DIR)/local/include -std=gnu99 -Wall -DDEBUG -DVISIBLE
-CFLAGS := -fPIC -c -O0 -I include -Wno-undef -I include -I $(ROOT_DIR)/include -std=gnu99  -Wall
+CFLAGS := -fPIC -c -O0 -I include -Wno-undef -I include -I $(ROOT_DIR)/local/include -std=gnu99  -Wall
 #CPPFLAGS := -c -O2 -std=c++17 -I ./ -I include  -I $(ROOT_DIR)/local/include -Wno-deprecated-declarations  -DDEBUG -DVISIBLE
 #CPPFLAGS := -c -O2 -std=c++17 -Wno-undef -I include -I $(ROOT_DIR)/local/include -Wno-deprecated-declarations -DSSL -DDEBUG
-CPPFLAGS := -fPIC -c -O0 -std=c++17 -Wno-undef -I include -I $(ROOT_DIR)/include -Werror -Wall -Wno-deprecated-declarations
+CPPFLAGS := -fPIC -c -O0 -std=c++17 -Wno-undef -I include -I $(ROOT_DIR)/local/include -Werror -Wall -Wno-deprecated-declarations
 #
 #
 # Link Flags
 #
-LIBDIR := $(ROOT_DIR)/lib
-LIB64DIR := $(ROOT_DIR)/lib64
+LIBDIR := $(ROOT_DIR)/local/lib
+LIB64DIR := $(ROOT_DIR)/local/lib64
 #
 GPR_LIB := $(LIBDIR)/libgpr.a
-CHANNELZ_LIB := $(LIBDIR)/libgrpcpp_channelz.a
+CHANNELZ_LIB := $(LIB64DIR)/libgrpcpp_channelz.a
 GRPCPP_LIB := $(LIBDIR)/libgrpc++.a
 GRPC_LIB := $(LIBDIR)/libgrpc.a
-PROTOBUF_LIB := $(LIBDIR)/libprotobuf.a
-CARES_LIB := $(LIBDIR)/libcares.a
-REFLECTION_LIB := $(LIBDIR)/libgrpc++_reflection.a
+PROTOBUF_LIB := $(LIB64DIR)/libprotobuf.a
+CARES_LIB := $(LIB64DIR)/libcares.a
+REFLECTION_LIB := $(LIB64DIR)/libgrpc++_reflection.a
 UPB_LIB := $(LIBDIR)/libupb.a
-ABSL_BASE_LIB := $(LIBDIR)/libabsl_base.a
-ABSL_FORMAT_LIB := $(LIBDIR)/libabsl_str_format_internal.a
-ABSL_INT28_LIB := $(LIBDIR)/libabsl_int128.a
-ABSL_STRINGS_LIB := $(LIBDIR)/libabsl_strings.a 
-ABSL_BAD_LIB := $(LIBDIR)/libabsl_bad_optional_access.a
+ABSL_BASE_LIB := $(LIB64DIR)/libabsl_base.a
+ABSL_FORMAT_LIB := $(LIB64DIR)/libabsl_str_format_internal.a
+ABSL_INT28_LIB := $(LIB64DIR)/libabsl_int128.a
+ABSL_STRINGS_LIB := $(LIB64DIR)/libabsl_strings.a
+ABSL_BAD_LIB := $(LIB64DIR)/libabsl_bad_optional_access.a
 SSL_LIB := $(LIBDIR)/libssl.a
 CRYPTO_LIB := $(LIBDIR)/libcrypto.a
-ABSL_STR_INTERNAL_LIB := $(LIBDIR)/libabsl_strings_internal.a 
+ABSL_STR_INTERNAL_LIB := $(LIB64DIR)/libabsl_strings_internal.a
 ADDRESS_SORT_LIB := $(LIBDIR)/libaddress_sorting.a
 Z_LIB := $(LIBDIR)/libz.a
-ABSL_LOGGING_LIB := $(LIBDIR)/libabsl_raw_logging_internal.a 
-ABSL_THROW := $(LIBDIR)/libabsl_throw_delegate.a
-ABSL_TIME_LIB := $(LIBDIR)/libabsl_time.a
-ABSL_TIME_ZONE_LIB := $(LIBDIR)/libabsl_time_zone.a
-ABSL_SYNC_LIB := $(LIBDIR)/libabsl_synchronization.a
-ABSL_STATUS_LIB := $(LIBDIR)/libabsl_status.a
-ABSL_CORD_LIB := $(LIBDIR)/libabsl_cord.a
-ABSL_CORD_INT := $(LIBDIR)/libabsl_cord_internal.a
-ABSL_STATUSOR_LIB := $(LIBDIR)/libabsl_statusor.a
-ABSL_RAND_DIST_LIB := $(LIBDIR)/libabsl_random_distributions.a
-ABSL_RAND_INT_HWAES := $(LIBDIR)/libabsl_random_internal_randen_hwaes.a
-ABSL_RAND_INT_HWAES_IMPL := $(LIBDIR)/libabsl_random_internal_randen_hwaes_impl.a
-ABSL_RAND_INT_RAND_SLOW := $(LIBDIR)/libabsl_random_internal_randen_slow.a
-ABSL_RAND_INT_RAND := $(LIBDIR)/libabsl_random_internal_randen.a
-ABSL_RAND_INT_POOL_URBG := $(LIBDIR)/libabsl_random_internal_pool_urbg.a
-ABSL_RAND_INT_PLAT := $(LIBDIR)/libabsl_random_internal_platform.a
-ABSL_RAND_INT_SEED_MAT := $(LIBDIR)/libabsl_random_internal_seed_material.a
-ABSL_RAND_SEED_GEN_EXEC := $(LIBDIR)/libabsl_random_seed_gen_exception.a
-ABSL_RAW_HASH_SET := $(LIBDIR)/libabsl_raw_hash_set.a
-ABSL_HASH := $(LIBDIR)/libabsl_hash.a
-ABSL_CORDZ_INFO := $(LIBDIR)/libabsl_cordz_info.a
-ABSL_CORDZ_FUNC := $(LIBDIR)/libabsl_cordz_functions.a
-ABSL_CORDZ_HANDLE := $(LIBDIR)/libabsl_cordz_handle.a
-ABSL_STR_ERR := $(LIBDIR)/libabsl_strerror.a
-RE2 := $(LIBDIR)/libre2.a
-ABSL_SPINLOCK_WAIT := $(LIBDIR)/libabsl_spinlock_wait.a
-ABSL_MALLOC_INT := $(LIBDIR)/libabsl_malloc_internal.a
-ABSL_STACK_TRACE := $(LIBDIR)/libabsl_stacktrace.a
-ABSL_GRAPHCYCLES_INT := $(LIBDIR)/libabsl_graphcycles_internal.a
-ABSL_SYMBOLIZE := $(LIBDIR)/libabsl_symbolize.a
-ABSL_THROW_DELEGATE := $(LIBDIR)/libabsl_throw_delegate.a
-ABSL_CITY := $(LIBDIR)/libabsl_city.a
-ABSL_LOW_LEVEL_HASH := $(LIBDIR)/libabsl_low_level_hash.a
-ABSL_EXP_BIAS := $(LIBDIR)/libabsl_exponential_biased.a
-ABSL_DEBUG_INTERNAL := $(LIBDIR)/libabsl_debugging_internal.a
-ABSL_SYMBOLIZE := $(LIBDIR)/libabsl_symbolize.a
-ABSL_DEMANGLE := $(LIBDIR)/libabsl_demangle_internal.a
+ABSL_LOGGING_LIB := $(LIB64DIR)/libabsl_raw_logging_internal.a
+ABSL_THROW := $(LIB64DIR)/libabsl_throw_delegate.a
+ABSL_TIME_LIB := $(LIB64DIR)/libabsl_time.a
+ABSL_TIME_ZONE_LIB := $(LIB64DIR)/libabsl_time_zone.a
+ABSL_SYNC_LIB := $(LIB64DIR)/libabsl_synchronization.a
+ABSL_STATUS_LIB := $(LIB64DIR)/libabsl_status.a
+ABSL_CORD_LIB := $(LIB64DIR)/libabsl_cord.a
+ABSL_CORD_INT := $(LIB64DIR)/libabsl_cord_internal.a
+ABSL_STATUSOR_LIB := $(LIB64DIR)/libabsl_statusor.a
+ABSL_RAND_DIST_LIB := $(LIB64DIR)/libabsl_random_distributions.a
+ABSL_RAND_INT_HWAES := $(LIB64DIR)/libabsl_random_internal_randen_hwaes.a
+ABSL_RAND_INT_HWAES_IMPL := $(LIB64DIR)/libabsl_random_internal_randen_hwaes_impl.a
+ABSL_RAND_INT_RAND_SLOW := $(LIB64DIR)/libabsl_random_internal_randen_slow.a
+ABSL_RAND_INT_RAND := $(LIB64DIR)/libabsl_random_internal_randen.a
+ABSL_RAND_INT_POOL_URBG := $(LIB64DIR)/libabsl_random_internal_pool_urbg.a
+ABSL_RAND_INT_PLAT := $(LIB64DIR)/libabsl_random_internal_platform.a
+ABSL_RAND_INT_SEED_MAT := $(LIB64DIR)/libabsl_random_internal_seed_material.a
+ABSL_RAND_SEED_GEN_EXEC := $(LIB64DIR)/libabsl_random_seed_gen_exception.a
+ABSL_RAW_HASH_SET := $(LIB64DIR)/libabsl_raw_hash_set.a
+ABSL_HASH := $(LIB64DIR)/libabsl_hash.a
+ABSL_CORDZ_INFO := $(LIB64DIR)/libabsl_cordz_info.a
+ABSL_CORDZ_FUNC := $(LIB64DIR)/libabsl_cordz_functions.a
+ABSL_CORDZ_HANDLE := $(LIB64DIR)/libabsl_cordz_handle.a
+ABSL_STR_ERR := $(LIB64DIR)/libabsl_strerror.a
+RE2 := $(LIB64DIR)/libre2.a
+ABSL_SPINLOCK_WAIT := $(LIB64DIR)/libabsl_spinlock_wait.a
+ABSL_MALLOC_INT := $(LIB64DIR)/libabsl_malloc_internal.a
+ABSL_STACK_TRACE := $(LIB64DIR)/libabsl_stacktrace.a
+ABSL_GRAPHCYCLES_INT := $(LIB64DIR)/libabsl_graphcycles_internal.a
+ABSL_SYMBOLIZE := $(LIB64DIR)/libabsl_symbolize.a
+ABSL_THROW_DELEGATE := $(LIB64DIR)/libabsl_throw_delegate.a
+ABSL_CITY := $(LIB64DIR)/libabsl_city.a
+ABSL_LOW_LEVEL_HASH := $(LIB64DIR)/libabsl_low_level_hash.a
+ABSL_EXP_BIAS := $(LIB64DIR)/libabsl_exponential_biased.a
+ABSL_DEBUG_INTERNAL := $(LIB64DIR)/libabsl_debugging_internal.a
+ABSL_SYMBOLIZE := $(LIB64DIR)/libabsl_symbolize.a
+ABSL_DEMANGLE := $(LIB64DIR)/libabsl_demangle_internal.a
 
 
 LD = g++ -g
 #LDFLAGS = -lc  -lc++ -lgrpc++ -lprotobuf -L~/.local/lib -L /opt/local/lib
-LIBCONFIG := /usr/lib/x86_64-linux-gnu/libconfig.a
+LIBCONFIG := /usr/local/lib/libconfig.a
 LDFLAGS = -lc  -lstdc++ -pthread 
 SERVERFLAGS =  -L $(LIB_DIR) -lopof_server
 CLIENTFLAGS =  -L $(LIB_DIR) -lopof_client
@@ -228,15 +228,13 @@ $(DIRECTORIES):
 # Generate gPRC files
 #
 $(PROTO_NAME).pb.cc: $(PROTO_NAME).proto
-	docker run -v "${PWD}/${MOUNT_PATH}":/defs namely/protoc-all --lint -d ./sessionoffload/v2 -l cpp -o ./openoffload/cpp/framework/src  --go-source-relative
-	#$(PROTOC) -I $(PROTOS_PATH) --cpp_out=src $(PROTO_NAME).proto
-	mv src/$(PROTO_NAME).pb.h $(INC_DIR)
-	mv src/$(PROTO_NAME).grpc.pb.h $(INC_DIR)
+	$(PROTOC) --cpp_out=src $(PROTO_NAME).proto
+	mv src/$(PROTO_NAME).pb.h include/
 #
 $(PROTO_NAME).grpc.pb.cc: $(PROTO_NAME).proto
-	docker run -v "${PWD}/${MOUNT_PATH}":/defs namely/protoc-all --lint -d ./sessionoffload/v2 -l cpp -o ./openoffload/cpp/framework/src  --go-source-relative
-	#$(PROTOC) -I $(PROTOS_PATH) --grpc_out=src --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN_PATH) $<
-	mv src/$(PROTO_NAME).grpc.pb.h $(INC_DIR)
+	$(PROTOC) --grpc_out=src --plugin=protoc-gen-grpc=$(GRPC_CPP_PLUGIN_PATH) $<
+	mv src/$(PROTO_NAME).grpc.pb.h include/
+
 #
 #$(PROTOS):  $(PROTO_NAME).grpc.pb.cc $(PROTO_NAME).pb.cc
 $(PROTOS):  $(PROTO_NAME).pb.cc

--- a/openoffload/cpp/framework/README.md
+++ b/openoffload/cpp/framework/README.md
@@ -23,9 +23,9 @@ Libconfig is used to configure test files the the test client only.
 [libconfig install instructions](https://github.com/hyperrealm/libconfig/blob/master/INSTALL)
 
 ```bash
-wget http://hyperrealm.github.io/libconfig/dist/libconfig-1.7.2.tar.gz
-tar xvzf libconfig-1.7.2.tar.gz
-cd libconfig-1.7.2
+wget http://hyperrealm.github.io/libconfig/dist/libconfig-1.7.3.tar.gz
+tar xvzf libconfig-1.7.3.tar.gz
+cd libconfig-1.7.3
 ./configure
 make 
 sudo make install
@@ -64,18 +64,21 @@ This will print out links to libconfig.so
 ```bash
 mkdir -p $HOME/local
 export GRPC_INSTALL=$HOME/local
-wget --no-check-certificate -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.17.5/cmake-3.17.5-Linux-x86_64.sh
+wget --no-check-certificate -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.23.4/cmake-3.23.4-Linux-x86_64.sh
 ./cmake-linux.sh  -- --skip-license --prefix=$HOME/local
 rm cmake-linux.sh
 export PATH=$GRPC_INSTALL/bin:$PATH
 git config --global  http.sslVerify false
-git clone --recurse-submodules -b v1.30.0 https://github.com/grpc/grpc
+git clone --recurse-submodules -b v1.49.1 https://github.com/grpc/grpc
 cd grpc 
 mkdir -p $GRPC_INSTALL/grpc/cmake/build
 pushd cmake/build
 cmake -DgRPC_INSTALL=ON \
       -DgRPC_BUILD_TESTS=OFF \
       -DCMAKE_INSTALL_PREFIX=$GRPC_INSTALL \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE \
+      -DCMAKE_CXX_STANDARD=17 \
+      -DABSL_PROPAGATE_CXX_STD=TRUE \
       ../..
 make -j 4
 make install

--- a/openoffload/cpp/framework/build/Dockerfile
+++ b/openoffload/cpp/framework/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8.4.2105
+FROM rockylinux:9
 USER root
 
 RUN mkdir -p /home/grpc/local
@@ -11,16 +11,17 @@ RUN echo $GRPC_INSTALL && \
     yum -y install wget && \
     yum -y install which && \
     yum -y groupinstall "Development tools" && \
-    yum clean all && \
-    wget --no-check-certificate -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.17.5/cmake-3.17.5-Linux-x86_64.sh && \
-    cmake-linux.sh -- --skip-license --prefix=/home/grpc/local && \
+    yum clean all
+
+RUN wget --no-check-certificate -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.23.4/cmake-3.23.4-linux-x86_64.sh && \
+    sh ./cmake-linux.sh -- --skip-license --prefix=/home/grpc/local && \
     rm cmake-linux.sh
 
 ENV PATH="$GRPC_INSTALL/bin:${PATH}"
 
 RUN echo $PATH && \
     git config --global http.sslVerify false && \
-    git clone --recurse-submodules -b v1.30.0 https://github.com/grpc/grpc grpc && \
+    git clone --recurse-submodules -b v1.49.1 https://github.com/grpc/grpc grpc && \
     mkdir -p /home/grpc/local/grpc/cmake/build
 
 WORKDIR /home/grpc/local/grpc/cmake/build
@@ -30,17 +31,17 @@ RUN echo $PATH
 #CMD ["sh", "-c", "tail -f /dev/null"]
 
 RUN pwd && \
-    cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/home/grpc/local ../.. && \
+    cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/home/grpc/local -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DCMAKE_CXX_STANDARD=17 -DABSL_PROPAGATE_CXX_STD=TRUE ../.. && \
     make -j 4 && \
     make install && \
     mkdir -p /home/grpc/tmp
 
 WORKDIR /home/grpc/tmp
 
-RUN wget -nv http://hyperrealm.github.io/libconfig/dist/libconfig-1.7.2.tar.gz && \
-    tar xvzf libconfig-1.7.2.tar.gz
+RUN wget -nv http://hyperrealm.github.io/libconfig/dist/libconfig-1.7.3.tar.gz && \
+    tar xvzf libconfig-1.7.3.tar.gz
 
-WORKDIR /home/grpc/tmp/libconfig-1.7.2
+WORKDIR /home/grpc/tmp/libconfig-1.7.3
 
 RUN ./configure && \
     make && \
@@ -48,5 +49,4 @@ RUN ./configure && \
 
 WORKDIR /home/grpc/
 #
-USER guest
 CMD ["sh", "-c", "tail -f /dev/null"]

--- a/openoffload/cpp/framework/include/opof_grpc.h
+++ b/openoffload/cpp/framework/include/opof_grpc.h
@@ -49,21 +49,21 @@ using grpc::ServerReader;
 using grpc::ServerWriter;
 using grpc::ClientWriter;
 //
-using openoffload::v1::SessionTable;
-using openoffload::v1::SessionRequest;
-using openoffload::v1::SessionRequestArgs;
-using openoffload::v1::AddSessionResponse;
-using openoffload::v1::SessionResponse;
-using openoffload::v1::SessionResponses;
-using openoffload::v1::SessionResponseError;
-using openoffload::v1::SessionId;
-using openoffload::v1::IpVersion;
-using openoffload::v1::ProtocolId;
-using openoffload::v1::ActionType;
-using openoffload::v1::RequestStatus;
-using openoffload::v1::AddSessionStatus;
-using openoffload::v1::SessionState;
-using openoffload::v1::SessionCloseCode;
-using openoffload::v1::ActionParameters;
+using openoffload::v2::SessionTable;
+using openoffload::v2::SessionRequest;
+using openoffload::v2::SessionRequestArgs;
+using openoffload::v2::AddSessionResponse;
+using openoffload::v2::SessionResponse;
+using openoffload::v2::SessionResponses;
+using openoffload::v2::SessionResponseError;
+using openoffload::v2::SessionId;
+using openoffload::v2::IpVersion;
+using openoffload::v2::ProtocolId;
+using openoffload::v2::ActionType;
+using openoffload::v2::RequestStatus;
+using openoffload::v2::AddSessionStatus;
+using openoffload::v2::SessionState;
+using openoffload::v2::SessionCloseCode;
+using openoffload::v2::ActionParameters;
 
 #endif // _OPOF_GRPC_H


### PR DESCRIPTION
This moves back to the somewhat byzantine way that sessionOffload is currently built. It does, however, update some components. Instead of the since abandoned (pour one out) CentOS, we move to Rocky Linux. We also update the versions of cmake, grpc, and libconfig.

Signed-off-by: Kyle Mestery <mestery@mestery.com>