### PR TITLE
ci: Update CI to build and save protobufs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,36 +51,65 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3.1.0
+    - name: Checkout repository
+      uses: actions/checkout@v3.1.0
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    # Workaround: https://github.com/docker/build-push-action/issues/461
+    - name: Setup Docker buildx
+      uses: docker/setup-buildx-action@8c0edbc76e98fa90f69d9a2c020dcb50019dc325
+
+    - name: Build protobufs
+      run: make
+      working-directory: sessionoffload
+
+    - name: Check uncomitted auto generated protobufs
+      run: git diff --exit-code
+      working-directory: sessionoffload
+
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v3
+      with:
+        path: sessionoffload/v2/gen
+        retention-days: 7
+
     - name: Set up JDK 1.8
       uses: actions/setup-java@v3
       with:
         java-version: 17
         distribution: corretto
+
     - uses: actions/setup-python@v4
       with:
         python-version: '2.x'
         architecture:  'x64'
+
     - uses: actions/setup-python@v4
       with:
          python-version: '3.7' # Version range or exact version of a Python version to use, using SemVer's version range syntax
          architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip3 install grpcio grpcio-tools pudb
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi  
+
     - name: Build with Maven
       run: mvn clean install --file pom.xml
+
     - name: Delete output.xml (on Unix-like)
       run: |
         find $GITHUB_WORKSPACE/tests/robot/target/robotframework-reports -type f -name 'output.xml' -exec rm {} +
       if: always() 
+
     - name: Archive acceptances test results
       uses: actions/upload-artifact@v3
       with:
           name: robot-results
           path: tests/robot/target/robotframework-reports
+          retention-days: 7
       if: always()


### PR DESCRIPTION
This commit updates the CI to build and save the protobufs. Also, similar to [1], this will fail if a committer fails to auto-generate the C++, golang, and Python code.

[1] https://github.com/opiproject/opi-api/pull/167

Signed-off-by: Kyle Mestery <mestery@mestery.com>