### PR TITLE
golang: Save altered session in session map

### DIFF
--- a/openoffload/go/server/sessionoffload.go
+++ b/openoffload/go/server/sessionoffload.go
@@ -76,8 +76,17 @@ func session_update() {
 			v.in_bytes    += uint64(rand.Intn(100000))
 			v.out_bytes   += uint64(rand.Intn(100000))
 
+			// Save the new session in the session map
+			sessions[k] = v
+
+			// Use v for printing the output again
+			v = sessions[k]
+
 			// Dump the session
-			log.Printf("Session %d: %v", k, v)
+			log.Printf("Session %d: ID: [%d] State: [%s] In packets/bytes [%d/%d] Out packets/bytes [%d/%d]",
+				k, v.session_id, v.session_state.String(),
+				v.in_packets, v.in_bytes,
+				v.out_packets, v.out_bytes)
 
 			session_lock.RUnlock()
 		}


### PR DESCRIPTION
In the session_update thread, make sure that after we alter a session, we also save it in the session map. While here, adjust the printing of the session data as well.

Signed-off-by: Kyle Mestery <mestery@mestery.com>