### PR TITLE
CI: Collect logs after tests

### DIFF
--- a/.github/workflows/framework-golang-skip.yml
+++ b/.github/workflows/framework-golang-skip.yml
@@ -7,13 +7,13 @@ on:
     paths-ignore:
       - 'openoffload/go/**'
       - 'sessionoffload/**'
-      - '.github/workflows/framework.yml'
+      - '.github/workflows/framework-golang.yml'
   pull_request:
     branches: [ main ]
     paths-ignore:
       - 'openoffload/go/**'
       - 'sessionoffload/**'
-      - '.github/workflows/framework.yml'
+      - '.github/workflows/framework-golang.yml'
 
 concurrency:
   # if workflow for PR or push is already running stop it, and start new one

--- a/.github/workflows/framework-golang.yml
+++ b/.github/workflows/framework-golang.yml
@@ -8,13 +8,13 @@ on:
     paths:
       - 'openoffload/go/**'
       - 'sessionoffload/**'
-      - '.github/workflows/framework.yml'
+      - '.github/workflows/framework-golang.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'openoffload/go/**'
       - 'sessionoffload/**'
-      - '.github/workflows/framework.yml'
+      - '.github/workflows/framework-golang.yml'
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/framework-golang.yml
+++ b/.github/workflows/framework-golang.yml
@@ -105,11 +105,10 @@ jobs:
         "${grpc_cli[@]}" ls opi-offload-server:50151 openoffload.v2.SessionTable.DeleteSession -l
         "${grpc_cli[@]}" ls opi-offload-server:50151 openoffload.v2.SessionTable.GetAllSessions -l
         "${grpc_cli[@]}" ls opi-offload-server:50151 openoffload.v2.SessionTable.GetClosedSessions -l
-        docker-compose down
       working-directory: openoffload/go
 
     - name: Logs
-      if: failure()
+      if: always()
       run: docker-compose logs
       working-directory: openoffload/go
 


### PR DESCRIPTION
* docker-compose down was being run before collecting logs which loses all log data
* Collect the logs in all cases instead of only on failure to sync with security poc

Signed-off-by: Steven Royer <sroyer@redhat.com>