### PR TITLE
go: Make the server simulation configurable

### DIFF
--- a/openoffload/go/docker-compose.yml
+++ b/openoffload/go/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     networks:
       - internet
       - intranet
-    command: /opi-sessionoffload-bridge -port=50151
+    command: /opi-sessionoffload-bridge -port=50151 -simulate 7
 
   opi-offload-client:
     build:

--- a/openoffload/go/server/server.go
+++ b/openoffload/go/server/server.go
@@ -18,7 +18,7 @@ var (
 	port           = flag.Int("port", 50151, "The server port")
 	start_session  = flag.Uint64("start", 1, "The starting session ID")
 	max_session    = flag.Uint64("max", 8192, "The maximum session ID")
-	update         = flag.Int("update", 10, "Delay for each session update run")
+	update         = flag.Int("simulate", 0, "Enable simulation with a delay per run, disabled by default")
 )
 
 type server struct {

--- a/openoffload/go/server/sessionoffload.go
+++ b/openoffload/go/server/sessionoffload.go
@@ -106,7 +106,9 @@ func init_sessionoffload() {
 	sessions = make(map[uint64]session)
 	last = *start_session
 	max  = *max_session
-	go session_update()
+	if *update != 0 {
+		go session_update()
+	}
 }
 
 func next_session_id() (uint64, error) {


### PR DESCRIPTION
Modify the server to allow for the simulation thread to be configurable at startup.

Signed-off-by: Kyle Mestery <mestery@mestery.com>