### PR TITLE
golang: Beef up client and fix server bugs

### DIFF
--- a/openoffload/go/client/client.go
+++ b/openoffload/go/client/client.go
@@ -33,4 +33,8 @@ func main() {
 	defer cancel()
 
 	do_sessionoffload(conn, ctx)
+
+	done := make(chan bool)
+	go do_client_background(conn, done)
+	<-done
 }

--- a/openoffload/go/client/client.go
+++ b/openoffload/go/client/client.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"log"
 	"math/rand"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -34,7 +35,8 @@ func main() {
 
 	do_sessionoffload(conn, ctx)
 
-	done := make(chan bool)
-	go do_client_background(conn, done)
-	<-done
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go do_client_background(conn, &wg)
+	wg.Wait()
 }

--- a/openoffload/go/client/sessionoffload.go
+++ b/openoffload/go/client/sessionoffload.go
@@ -43,7 +43,7 @@ func do_sessionoffload(conn grpc.ClientConnInterface, ctx context.Context) {
 		log.Printf("close and receive: %v", err)
 	}
 
-	log.Printf("%+v\n", response)
+	log.Printf("Response: %v\n", response)
 
 	// Load a few more sessions
 	add_session_requests2 := []*fw.SessionRequest{
@@ -68,5 +68,5 @@ func do_sessionoffload(conn grpc.ClientConnInterface, ctx context.Context) {
 		log.Printf("close and receive: %v", err)
 	}
 
-	log.Printf("%+v\n", response)
+	log.Printf("Response: %v\n", response)
 }

--- a/openoffload/go/client/sessionoffload_thread.go
+++ b/openoffload/go/client/sessionoffload_thread.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2022 Intel Corporation, or its subsidiaries.
+//
+// This file contains the logic for the client thead, which will run
+// and verify sessions with the server, removing sessions which are
+// closed.
+
+package main
+
+import (
+	"context"
+	"io"
+        "log"
+        "time"
+
+        fw "github.com/opiproject/sessionOffload/sessionoffload/v2/gen/go"
+	"google.golang.org/grpc"
+)
+
+func do_client_background(conn grpc.ClientConnInterface, ch chan<- bool) {
+	log.Printf("----- Entered do_client_background -----")
+
+	// Count sessions
+	count := 0
+
+	// Session Offload client
+	client := fw.NewSessionTableClient(conn)
+
+	for {
+		count = 0
+
+		time.Sleep(time.Duration(10) * time.Second)
+
+		// Get all the sessions
+		request_args := &fw.SessionRequestArgs{
+			StartSession: 0,
+		}
+
+		stream, err := client.GetClosedSessions(context.Background(), request_args)
+		if err != nil {
+			log.Fatalf("open stream error %v", err)
+		}
+
+		done := make(chan bool)
+
+		go func(client fw.SessionTableClient) {
+			for {
+				resp, err := stream.Recv()
+				if err == io.EOF {
+					done <- true //means stream is finished
+					return
+				}
+				if err != nil {
+					log.Fatalf("cannot receive %v", err)
+				}
+				count++
+
+				sess_id := &fw.SessionId{
+					SessionId: resp.SessionId,
+				}
+
+				// Clear out this session
+				_, err = client.DeleteSession(context.Background(), sess_id)
+				if err != nil {
+					log.Printf("Failed removing session %d", sess_id.SessionId)
+				}
+			}
+		}(client)
+
+		<-done //we will wait until all response is received
+		log.Printf("finished")
+
+		// Get current sessions
+		all_sessions, sess_err := client.GetAllSessions(context.Background(), request_args)
+		if sess_err != nil {
+			log.Printf("Error contacting server")
+			done <- true
+			return
+		}
+
+		if len(all_sessions.SessionInfo) == 0 && count == 0 {
+			// Exit as we processed all closed sessions
+			log.Printf("All sessions closed, returning")
+			done <- true
+			return
+		}
+	}
+}

--- a/openoffload/go/server/sessionoffload.go
+++ b/openoffload/go/server/sessionoffload.go
@@ -239,6 +239,9 @@ func (s *server) DeleteSession(ctx context.Context, in *fw.SessionId) (*fw.Sessi
 	session_lock.Lock()
 	defer session_lock.Unlock()
 
+	log.Printf("----- DELETE SESSION -----")
+	log.Printf("Looking for session %d", in.SessionId)
+
 	session, valid := sessions[in.SessionId]
 	if !valid {
 		log.Printf("Session not found")
@@ -263,15 +266,18 @@ func (s *server) DeleteSession(ctx context.Context, in *fw.SessionId) (*fw.Sessi
 	return return_session, nil
 }
 
-func (s *server) GetAllSession(ctx context.Context, in *fw.SessionRequestArgs) (*fw.SessionResponses, error) {
+func (s *server) GetAllSessions(ctx context.Context, in *fw.SessionRequestArgs) (*fw.SessionResponses, error) {
 	var return_sessions fw.SessionResponses
+
+	log.Printf("----- GET ALL SESSIONS -----")
+	log.Printf("Starting with session %d", in.StartSession)
 
 	session_lock.RLock()
 	defer session_lock.RUnlock()
 
 	for k, v := range sessions {
 		// Skip if requested session start is greater than current session
-		if k > in.StartSession {
+		if k < in.StartSession {
 			continue
 		}
 
@@ -303,33 +309,34 @@ func (s *server) GetClosedSessions(in *fw.SessionRequestArgs, stream fw.SessionT
 	defer session_lock.RUnlock()
 
 	for _, v := range sessions {
-		if v.session_state == fw.SessionState__CLOSED {
+		if v.session_state != fw.SessionState__CLOSED {
 			continue
 		}
 
 		// Stream this session
 		wg.Add(1)
 
-		// Collect the response
-		return_session := &fw.SessionResponse{
-			SessionId:        v.session_id,
-			InPackets:        v.in_packets,
-			OutPackets:       v.out_packets,
-			InBytes:          v.in_bytes,
-			OutBytes:         v.out_bytes,
-			SessionState:     v.session_state,
-			SessionCloseCode: v.session_close_code,
-			RequestStatus:    v.request_status,
-			StartTime:        timestamppb.New(v.start_time),
-			EndTime:          timestamppb.New(v.end_time),
-		}
-		go func(session *fw.SessionResponse) {
+		go func(v session) {
 			defer wg.Done()
 
-			if err := stream.Send(session); err != nil {
+			// Collect the response
+			return_session := &fw.SessionResponse{
+				SessionId:        v.session_id,
+				InPackets:        v.in_packets,
+				OutPackets:       v.out_packets,
+				InBytes:          v.in_bytes,
+				OutBytes:         v.out_bytes,
+				SessionState:     v.session_state,
+				SessionCloseCode: v.session_close_code,
+				RequestStatus:    v.request_status,
+				StartTime:        timestamppb.New(v.start_time),
+				EndTime:          timestamppb.New(v.end_time),
+			}
+
+			if err := stream.Send(return_session); err != nil {
 				log.Printf("send error %v", err)
 			}
-		}(return_session)
+		}(v)
 	}
 
 	wg.Wait()

--- a/openoffload/go/server/sessionoffload_thread.go
+++ b/openoffload/go/server/sessionoffload_thread.go
@@ -19,10 +19,10 @@ import (
 // Update packet counters
 func session_update_packet_counters(v *session) {
 	// Increment packet counters
-	v.in_packets  += uint64(rand.Intn(1000))
-	v.out_packets += uint64(rand.Intn(1000))
-	v.in_bytes    += uint64(rand.Intn(100000))
-	v.out_bytes   += uint64(rand.Intn(100000))
+	v.in_packets  += uint64(rand.Intn(50))
+	v.out_packets += uint64(rand.Intn(700))
+	v.in_bytes    += uint64(rand.Intn(7000))
+	v.out_bytes   += uint64(rand.Intn(500000))
 }
 
 func session_timeout(v *session) {


### PR DESCRIPTION
Fixes a few bugs on the server:

* GetAllSessions() was incorrectly coded as GetAllSession()
* When iterating on sessions in GetAllSessions(), make sure to check the iterator is >= to the requested SessionId.
* Fix the stream return of GetAllClosedSessions().

Beefed up the client a lot as well. The client now spawns a go thread which runs in the background, checking for closed sessions and closing them.

Signed-off-by: Kyle Mestery <mestery@mestery.com>