### PR TITLE
XDP: Enable eBPF map update/delete

### DIFF
--- a/openoffload/go/server/sessionoffload.go
+++ b/openoffload/go/server/sessionoffload.go
@@ -224,7 +224,7 @@ func (s *server) GetSession(ctx context.Context, in *fw.SessionId) (*fw.SessionR
 	session_lock.RLock()
 	defer session_lock.RUnlock()
 
-	session, valid := sessions[uint32(in.SessionId >> 32)]
+	session, valid := sessions[uint32(in.SessionId)]
 	if !valid {
 		log.Printf("Session not found")
 		return nil, errors.New("Session not found")
@@ -259,7 +259,7 @@ func (s *server) DeleteSession(ctx context.Context, in *fw.SessionId) (*fw.Sessi
 	log.Printf("----- DELETE SESSION -----")
 	log.Printf("Looking for session %d", in.SessionId)
 
-	session, valid := sessions[uint32(in.SessionId >> 32)]
+	session, valid := sessions[uint32(in.SessionId)]
 	if !valid {
 		log.Printf("Session not found")
 		return nil, errors.New("Session not found")
@@ -278,7 +278,7 @@ func (s *server) DeleteSession(ctx context.Context, in *fw.SessionId) (*fw.Sessi
 		EndTime:          timestamppb.New(session.end_time),
 	}
 
-	delete(sessions, uint32(in.SessionId >> 32))
+	delete(sessions, uint32(in.SessionId))
 
 	if *xdp_backend {
 		_, err := xdp_del_session(uint32(in.SessionId))
@@ -301,7 +301,7 @@ func (s *server) GetAllSessions(ctx context.Context, in *fw.SessionRequestArgs) 
 
 	for k, v := range sessions {
 		// Skip if requested session start is greater than current session
-		if k < uint32(in.StartSession >> 32) {
+		if k < uint32(in.StartSession) {
 			continue
 		}
 

--- a/openoffload/go/server/sessionoffload_thread.go
+++ b/openoffload/go/server/sessionoffload_thread.go
@@ -23,18 +23,36 @@ func session_update_packet_counters(v *session) {
 	v.out_packets += uint64(rand.Intn(700))
 	v.in_bytes    += uint64(rand.Intn(7000))
 	v.out_bytes   += uint64(rand.Intn(500000))
+
+	if *xdp_backend {
+		if err := xdp_update_map_entry(v); err != nil {
+			log.Printf("Failed updating stats for eBPF map %d", v.session_id)
+		}
+	}
 }
 
 func session_timeout(v *session) {
 	v.session_state      = fw.SessionState__CLOSED
 	v.session_close_code = fw.SessionCloseCode__TIMEOUT
 	v.end_time           = time.Now()
+
+	if *xdp_backend {
+		if err := xdp_update_map_entry(v); err != nil {
+			log.Printf("Failed updating session timeout for eBPF map %d", v.session_id)
+		}
+	}
 }
 
 func session_fin(v *session) {
 	v.session_state      = fw.SessionState__CLOSED
 	v.session_close_code = fw.SessionCloseCode__FINACK
 	v.end_time           = time.Now()
+
+	if *xdp_backend {
+		if err := xdp_update_map_entry(v); err != nil {
+			log.Printf("Failed updating session fin for eBPF map %d", v.session_id)
+		}
+	}
 }
 
 // Function which runs in the background updating the session table entries


### PR DESCRIPTION
This integrates the eBPF/XDP backend with the testing thread such that eBPF maps are updated and deleted as the simulated thread runs. Useful for testing.

Also fixed some issues with casting uint64 values to uint32, as well as uint32 to uint16.

Related to #68

Signed-off-by: Kyle Mestery <mestery@mestery.com>